### PR TITLE
HTMLのclass名の指定誤り修正

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'show sell information', type: :feature, js: true do
     before { visit root_path }
 
     it 'test' do
-      expect(page).to have_css '.test'
+      expect(page).to have_css '.message'
     end
   end
 end


### PR DESCRIPTION
[components/Hello.vue](https://github.com/mpg-yamato-murakami/rails-webpack-template/blob/master/app/bundles/javascripts/components/HelloVue.vue) 見た感じ、class名間違ってそう。修正後に動くことは、kakari内で動作確認済みです。